### PR TITLE
Impl CallbackProcessor

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -11,6 +11,16 @@ parameters:
 			path: src/AbstractStaticQuery.php
 
 		-
+			message: "#^Method Teto\\\\SQL\\\\Processor\\\\CallbackProcessor\\:\\:processQuery\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Processor/CallbackProcessor.php
+
+		-
+			message: "#^Property Teto\\\\SQL\\\\Processor\\\\CallbackProcessor\\:\\:\\$callback with generic interface Teto\\\\SQL\\\\PDOInterface does not specify its types\\: T$#"
+			count: 1
+			path: src/Processor/CallbackProcessor.php
+
+		-
 			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array\\<int\\|string, string\\>\\)\\: string, Closure\\(array\\)\\: int\\|string given\\.$#"
 			count: 1
 			path: src/Processor/PregCallbackReplacer.php

--- a/src/PDOInterface.php
+++ b/src/PDOInterface.php
@@ -16,6 +16,8 @@ namespace Teto\SQL;
  * - Part of the variable name is substituted.
  *
  * @template T of \PDOStatement|PDOStatementInterface
+ * @phpstan-type teto_pdo \PDO|PDOInterface
+ * @phpstan-type teto_pdo_statement \PDOStatement|PDOStatementInterface
  */
 interface PDOInterface
 {

--- a/src/Processor/CallbackProcessor.php
+++ b/src/Processor/CallbackProcessor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Teto\SQL\Processor;
+
+use Closure;
+use Teto\SQL\ProcessorInterface;
+
+/**
+ * Define a processor using Closure
+ *
+ * @phpstan-import-type teto_pdo from \Teto\SQL\PDOInterface
+ */
+class CallbackProcessor implements ProcessorInterface
+{
+    /**
+     * @var Closure
+     * @phpstan-var Closure(teto_pdo, string, array<non-empty-string,mixed>, array<non-empty-string,mixed>): string
+     */
+    protected $callback;
+
+    public function __construct(Closure $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function processQuery($pdo, $sql, array $params, array &$bind_values)
+    {
+        return call_user_func_array($this->callback, [$pdo, $sql, $params, &$bind_values]);
+    }
+}

--- a/src/StaticQueryExecuteTrait.php
+++ b/src/StaticQueryExecuteTrait.php
@@ -59,7 +59,7 @@ trait StaticQueryExecuteTrait
         $stmt = static::build($pdo, $sql, $params);
         $stmt->execute();
 
-        $id = $pdo->lastInsertId($name);
+        $id = ($name === null) ? $pdo->lastInsertId() : $pdo->lastInsertId($name);
         assert($id !== false);
 
         return $id;

--- a/tests/Processor/CallbackProcessorTest.php
+++ b/tests/Processor/CallbackProcessorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Teto\SQL\Processor;
+
+use Teto\SQL\DummyPDO;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class CallbackProcessorTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function test()
+    {
+        $pdo = new DummyPDO();
+
+        $bind_values = [];
+
+        $called = false;
+        $subject = new CallbackProcessor(function ($pdo, $sql, array $params, array &$bind_values) use (&$called) {
+            assert($params === ['foo' => 'bar', 'buz' => 'buz']);
+            $called = true;
+            $bind_values = $params;
+            $bind_values[] = 'Bound!';
+            return 'Closure called!';
+        });
+
+        $params = ['foo' => 'bar', 'buz' => 'buz'];
+        $actual = $subject->processQuery($pdo, 'before query', $params, $bind_values);
+
+        $this->assertTrue($called);
+        $this->assertEquals($bind_values, ['foo' => 'bar', 'buz' => 'buz', 'Bound!']);
+        $this->assertSame($actual, 'Closure called!');
+    }
+}


### PR DESCRIPTION
## Use case

You can implements your original processor easily.

```php
$sql_logger = new CallbackProcessor(function ($pdo, $sql, array $params, array &$bind_values) {
    \Your\App\Logger::log('SQL', ['query' => $sql]);
    return $sql;
})
```

```php
$append_backtrace = new CallbackProcessor(function ($pdo, $sql, array $params, array &$bind_values) {
    $backtrace = implode(',', array_map(fn($b) => "{$b['file']}:{$b['line']}", debug_backtrace(0)));
    return "{$sql} /* {$backtrace} */";
})
```
